### PR TITLE
Add `GET /api/v1/transaction/` endpoint

### DIFF
--- a/src/main/java/com/rstachelczyk/budget/accessor/transaction/TransactionAccessor.java
+++ b/src/main/java/com/rstachelczyk/budget/accessor/transaction/TransactionAccessor.java
@@ -2,11 +2,7 @@ package com.rstachelczyk.budget.accessor.transaction;
 
 import com.rstachelczyk.budget.exception.TransactionNotFoundException;
 import com.rstachelczyk.budget.model.Transaction;
-
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/rstachelczyk/budget/accessor/transaction/TransactionAccessor.java
+++ b/src/main/java/com/rstachelczyk/budget/accessor/transaction/TransactionAccessor.java
@@ -2,8 +2,14 @@ package com.rstachelczyk.budget.accessor.transaction;
 
 import com.rstachelczyk.budget.exception.TransactionNotFoundException;
 import com.rstachelczyk.budget.model.Transaction;
+
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 /**
@@ -22,6 +28,18 @@ public class TransactionAccessor {
   ) {
     this.transactionRepository = transactionRepository;
     this.transactionEntityMapper = transactionEntityMapper;
+  }
+
+  /**
+   * Fetch transactions using pagination params and map each to DTO.
+   *
+   * @param pageable pagination params
+   * @return page of transaction DTOs
+   */
+  public Page<Transaction> fetchTransactions(Pageable pageable) {
+    Page<TransactionEntity> transactions = this.transactionRepository.findAll(pageable);
+
+    return transactions.map(this.transactionEntityMapper::map);
   }
 
   /**

--- a/src/main/java/com/rstachelczyk/budget/controller/TransactionController.java
+++ b/src/main/java/com/rstachelczyk/budget/controller/TransactionController.java
@@ -7,9 +7,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Transaction Controller.
@@ -26,18 +28,35 @@ public class TransactionController {
     this.transactionService = transactionService;
   }
 
+  /**
+   * Fetch list of transactions with pagination & sorting.
+   *
+   * @param page page number
+   * @param limit page limit
+   * @param sortBy field to sort by
+   * @param sortDir direction to sort in (asc, desc)
+   * @return page of transactions
+   */
+  // CHECKSTYLE:OFF
   @GetMapping("/")
   public ResponseEntity<Page<Transaction>> getTransactions(
-    @RequestParam(value = "page", defaultValue = AppConstants.DEFAULT_PAGE_NUMBER, required = false) Integer page,
-    @RequestParam(value = "limit", defaultValue = AppConstants.DEFAULT_PAGE_LIMIT, required = false) Integer limit,
-    @RequestParam(value = "sortBy", defaultValue = AppConstants.DEFAULT_SORT_BY, required = false) String sortBy,
-    @RequestParam(value = "sortDir", defaultValue = AppConstants.DEFAULT_SORT_DIR, required = false) String sortDir
+      @RequestParam(value = "page", defaultValue = AppConstants.DEFAULT_PAGE_NUMBER, required = false) Integer page,
+      @RequestParam(value = "limit", defaultValue = AppConstants.DEFAULT_PAGE_LIMIT, required = false) Integer limit,
+      @RequestParam(value = "sortBy", defaultValue = AppConstants.DEFAULT_SORT_BY, required = false) String sortBy,
+      @RequestParam(value = "sortDir", defaultValue = AppConstants.DEFAULT_SORT_DIR, required = false) String sortDir
   ) {
     return ResponseEntity.ok(
       this.transactionService.getTransactions(page, limit, sortBy, sortDir)
     );
   }
+  // CHECKSTYLE:ON
 
+  /**
+   * Fetch transaction by id.
+   *
+   * @param id transaction id
+   * @return transaction
+   */
   @GetMapping("/{id}")
   public ResponseEntity<Transaction> getTransaction(@PathVariable long id) {
     return ResponseEntity.ok(

--- a/src/main/java/com/rstachelczyk/budget/controller/TransactionController.java
+++ b/src/main/java/com/rstachelczyk/budget/controller/TransactionController.java
@@ -2,13 +2,14 @@ package com.rstachelczyk.budget.controller;
 
 import com.rstachelczyk.budget.model.Transaction;
 import com.rstachelczyk.budget.service.TransactionService;
+import com.rstachelczyk.budget.utils.AppConstants;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * Transaction Controller.
@@ -25,9 +26,23 @@ public class TransactionController {
     this.transactionService = transactionService;
   }
 
+  @GetMapping("/")
+  public ResponseEntity<Page<Transaction>> getTransactions(
+    @RequestParam(value = "page", defaultValue = AppConstants.DEFAULT_PAGE_NUMBER, required = false) Integer page,
+    @RequestParam(value = "limit", defaultValue = AppConstants.DEFAULT_PAGE_LIMIT, required = false) Integer limit,
+    @RequestParam(value = "sortBy", defaultValue = AppConstants.DEFAULT_SORT_BY, required = false) String sortBy,
+    @RequestParam(value = "sortDir", defaultValue = AppConstants.DEFAULT_SORT_DIR, required = false) String sortDir
+  ) {
+    return ResponseEntity.ok(
+      this.transactionService.getTransactions(page, limit, sortBy, sortDir)
+    );
+  }
+
   @GetMapping("/{id}")
   public ResponseEntity<Transaction> getTransaction(@PathVariable long id) {
-    return ResponseEntity.ok(this.transactionService.getTransaction(id));
+    return ResponseEntity.ok(
+      this.transactionService.getTransaction(id)
+    );
   }
 
   @GetMapping("/helloWorld")

--- a/src/main/java/com/rstachelczyk/budget/service/TransactionService.java
+++ b/src/main/java/com/rstachelczyk/budget/service/TransactionService.java
@@ -21,14 +21,30 @@ public class TransactionService {
     this.transactionAccessor = transactionAccessor;
   }
 
+  /**
+   * Fetch page of transactions.
+   *
+   * @param page page number
+   * @param limit page limit
+   * @param sortBy field to sort by
+   * @param sortDir sort direction (desc, asc)
+   * @return page of transaction DTO
+   */
   public Page<Transaction> getTransactions(int page, int limit, String sortBy, String sortDir) {
     Sort sort = sortDir.equalsIgnoreCase(Sort.Direction.ASC.name()) ? Sort.by(sortBy).ascending()
-      : Sort.by(sortBy).descending();
+        : Sort.by(sortBy).descending();
 
     Pageable pageable = PageRequest.of(page, limit, sort);
 
     return this.transactionAccessor.fetchTransactions(pageable);
   }
+
+  /**
+   * Fetch transaction by id.
+   *
+   * @param id transaction id
+   * @return transaction DTO
+   */
   public Transaction getTransaction(long id) {
     return this.transactionAccessor.fetchTransaction(id);
   }

--- a/src/main/java/com/rstachelczyk/budget/service/TransactionService.java
+++ b/src/main/java/com/rstachelczyk/budget/service/TransactionService.java
@@ -3,6 +3,10 @@ package com.rstachelczyk.budget.service;
 import com.rstachelczyk.budget.accessor.transaction.TransactionAccessor;
 import com.rstachelczyk.budget.model.Transaction;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 /**
@@ -17,6 +21,14 @@ public class TransactionService {
     this.transactionAccessor = transactionAccessor;
   }
 
+  public Page<Transaction> getTransactions(int page, int limit, String sortBy, String sortDir) {
+    Sort sort = sortDir.equalsIgnoreCase(Sort.Direction.ASC.name()) ? Sort.by(sortBy).ascending()
+      : Sort.by(sortBy).descending();
+
+    Pageable pageable = PageRequest.of(page, limit, sort);
+
+    return this.transactionAccessor.fetchTransactions(pageable);
+  }
   public Transaction getTransaction(long id) {
     return this.transactionAccessor.fetchTransaction(id);
   }

--- a/src/main/java/com/rstachelczyk/budget/utils/AppConstants.java
+++ b/src/main/java/com/rstachelczyk/budget/utils/AppConstants.java
@@ -1,0 +1,8 @@
+package com.rstachelczyk.budget.utils;
+
+public class AppConstants {
+  public static final String DEFAULT_PAGE_NUMBER = "0";
+  public static final String DEFAULT_PAGE_LIMIT = "20";
+  public static final String DEFAULT_SORT_BY = "id";
+  public static final String DEFAULT_SORT_DIR = "desc";
+}

--- a/src/main/java/com/rstachelczyk/budget/utils/AppConstants.java
+++ b/src/main/java/com/rstachelczyk/budget/utils/AppConstants.java
@@ -1,5 +1,8 @@
 package com.rstachelczyk.budget.utils;
 
+/**
+ * App Constants.
+ */
 public class AppConstants {
   public static final String DEFAULT_PAGE_NUMBER = "0";
   public static final String DEFAULT_PAGE_LIMIT = "20";

--- a/src/test/java/com/rstachelczyk/budget/accessor/transaction/TransactionAccessorTest.java
+++ b/src/test/java/com/rstachelczyk/budget/accessor/transaction/TransactionAccessorTest.java
@@ -1,5 +1,6 @@
 package com.rstachelczyk.budget.accessor.transaction;
 
+import static java.time.OffsetDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -8,6 +9,9 @@ import static org.mockito.Mockito.when;
 import com.rstachelczyk.budget.TestConstants;
 import com.rstachelczyk.budget.exception.TransactionNotFoundException;
 import com.rstachelczyk.budget.model.Transaction;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +19,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class TransactionAccessorTest {
@@ -27,6 +35,25 @@ class TransactionAccessorTest {
 
   @InjectMocks
   private TransactionAccessor transactionAccessor;
+
+  @Test
+  @DisplayName("When given pagination params, fetches transactions and converts to DTO")
+  void whenGivenPageable_fetchTransactions_successfullyReturnsPageOfTransactionDTO() {
+    Pageable page = PageRequest.of(0, 20);
+
+    List<TransactionEntity> mockTransactionEntityList = List.of(
+      new TransactionEntity(1L, "test 1", 1000L, now()),
+      new TransactionEntity(2L, "test 2", 1000L, now()),
+      new TransactionEntity(3L, "test 3", 1000L, now())
+    );
+    Page<TransactionEntity> mockRepositoryResponse = new PageImpl<>(mockTransactionEntityList);
+
+    when(transactionRepositoryMock.findAll(page)).thenReturn(mockRepositoryResponse);
+
+    Page<Transaction> result = this.transactionAccessor.fetchTransactions(page);
+
+    assertThat(result.getSize()).isEqualTo(mockRepositoryResponse.getSize());
+  }
 
   @Test
   @DisplayName("When Transaction record exists, finds record and maps to DTO")

--- a/src/test/java/com/rstachelczyk/budget/service/TransactionServiceTest.java
+++ b/src/test/java/com/rstachelczyk/budget/service/TransactionServiceTest.java
@@ -2,17 +2,26 @@ package com.rstachelczyk.budget.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.rstachelczyk.budget.TestConstants;
 import com.rstachelczyk.budget.accessor.transaction.TransactionAccessor;
 import com.rstachelczyk.budget.model.Transaction;
+import com.rstachelczyk.budget.utils.AppConstants;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 class TransactionServiceTest {
@@ -22,6 +31,22 @@ class TransactionServiceTest {
 
   @InjectMocks
   private TransactionService transactionService;
+
+  @Test
+  @DisplayName("When fetching transaction list, returns Page of Transaction DTO")
+  void givenPageAndSortingParams_whenGetTransactions_thenReturnsTransactionsPage() {
+    List<Transaction> transactionList = new ArrayList<>();
+    Page<Transaction> pagedResult = new PageImpl<>(transactionList);
+
+    when(transactionAccessorMock.fetchTransactions(any(Pageable.class)))
+      .thenReturn(pagedResult);
+
+    Page<Transaction> response = this.transactionService.getTransactions(
+      0, 20, "id", "desc"
+    );
+
+    assertThat(response).isNotNull();
+  }
 
   @Test
   @DisplayName("When fetching a transaction by Id, returns Transaction DTO")


### PR DESCRIPTION
### Release Description:

Add `GET /api/v1/transaction/` endpoint to fetch transaction list

Supports `page`, `limit`, `sortBy`, and `sortDir` params for pagination
- [ ] POM Version Bump

### Test/Review
Tested locally end-to-end and added unit tests

### Migrations:

None

### New Permissions:

None

### New Environment Variables:

None
