### PR TITLE
Add `DELETE /api/v1/transaction/:id` endpoint

### DIFF
--- a/src/main/java/com/rstachelczyk/budget/accessor/transaction/TransactionAccessor.java
+++ b/src/main/java/com/rstachelczyk/budget/accessor/transaction/TransactionAccessor.java
@@ -77,4 +77,17 @@ public class TransactionAccessor {
 
     return this.transactionEntityMapper.map(transaction);
   }
+
+
+  /**
+   * Delete transaction by id.
+   *
+   * @param id transaction to be deleted
+   * @throws ResourceNotFoundException resource not found exception
+   */
+  public void deleteTransaction(long id) throws ResourceNotFoundException {
+    this.fetchTransaction(id);
+
+    this.transactionRepository.deleteById(id);
+  }
 }

--- a/src/main/java/com/rstachelczyk/budget/controller/TransactionController.java
+++ b/src/main/java/com/rstachelczyk/budget/controller/TransactionController.java
@@ -10,13 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * Transaction Controller.
@@ -83,6 +77,19 @@ public class TransactionController {
       this.transactionService.createTransaction(request),
       HttpStatus.CREATED
     );
+  }
+
+  /**
+   * Delete transaction by id.
+   *
+   * @param id transaction id
+   * @return transaction
+   */
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteTransaction(@PathVariable("id") final long id) {
+    this.transactionService.deleteTransaction(id);
+
+    return ResponseEntity.noContent().build();
   }
 
   @GetMapping("/helloWorld")

--- a/src/main/java/com/rstachelczyk/budget/controller/TransactionController.java
+++ b/src/main/java/com/rstachelczyk/budget/controller/TransactionController.java
@@ -10,7 +10,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Transaction Controller.

--- a/src/main/java/com/rstachelczyk/budget/service/TransactionService.java
+++ b/src/main/java/com/rstachelczyk/budget/service/TransactionService.java
@@ -80,4 +80,13 @@ public class TransactionService {
 
     return this.transactionAccessor.createTransaction(params, budget.get());
   }
+
+  /**
+   * Delete transaction by id.
+   *
+   * @param id transaction id
+   */
+  public void deleteTransaction(long id) {
+    this.transactionAccessor.deleteTransaction(id);
+  }
 }

--- a/src/test/java/com/rstachelczyk/budget/accessor/transaction/TransactionAccessorTest.java
+++ b/src/test/java/com/rstachelczyk/budget/accessor/transaction/TransactionAccessorTest.java
@@ -4,7 +4,7 @@ import static java.time.OffsetDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.rstachelczyk.budget.TestConstants;
 import com.rstachelczyk.budget.accessor.budget.BudgetEntity;
@@ -111,5 +111,35 @@ class TransactionAccessorTest {
     Transaction result = this.transactionAccessor.createTransaction(params, budget);
 
     assertThat(result).isNotNull();
+  }
+
+  @Test
+  @DisplayName("When Transaction record exists, deletes record")
+  void whenGivenValidId_deleteTransaction_successfullyDeletesTransaction() {
+    long id = TestConstants.LONG_OBJECT;
+
+    when(transactionRepositoryMock.findById(id)).thenReturn(Optional.of(new TransactionEntity()));
+
+    when(transactionEntityMapperMock.map(any(TransactionEntity.class)))
+      .thenReturn(new Transaction());
+
+    doNothing().when(transactionRepositoryMock).deleteById(id);
+
+    this.transactionAccessor.deleteTransaction(id);
+
+    verify(transactionRepositoryMock, times(1)).deleteById(id);
+  }
+
+  @Test
+  @DisplayName("When Transaction record doesn't exist, throws ResourceNotFoundException")
+  void whenGivenInvalidId_deleteTransaction_throwsResourceNotFoundException() {
+    long id = TestConstants.LONG;
+
+    when(transactionRepositoryMock.findById(id)).thenReturn(Optional.empty());
+
+    assertThrows(
+      ResourceNotFoundException.class,
+      () -> this.transactionAccessor.deleteTransaction(id)
+    );
   }
 }

--- a/src/test/java/com/rstachelczyk/budget/service/TransactionServiceTest.java
+++ b/src/test/java/com/rstachelczyk/budget/service/TransactionServiceTest.java
@@ -3,7 +3,7 @@ package com.rstachelczyk.budget.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.rstachelczyk.budget.TestConstants;
 import com.rstachelczyk.budget.accessor.budget.BudgetEntity;
@@ -78,5 +78,15 @@ class TransactionServiceTest {
     Transaction response = this.transactionService.createTransaction(params);
 
     assertThat(response).isNotNull();
+  }
+
+  @Test
+  @DisplayName("When deleting a transaction by Id, returns Transaction DTO")
+  void givenValidTransactionId_whenDeleteTransaction_thenDeletesTransaction() {
+    doNothing().when(transactionAccessorMock).deleteTransaction(anyLong());
+
+    this.transactionService.deleteTransaction(TestConstants.LONG);
+
+    verify(transactionAccessorMock, times(1)).deleteTransaction(TestConstants.LONG);
   }
 }


### PR DESCRIPTION
### Release Description:
Add transaction delete endpoint `DELETE /api/v1/transaction/:id`

- [ ] POM Version Bump

### Test/Review

Added unit tests and end-to-end postman tests

### Migrations:

No

### New Permissions:

No

### New Environment Variables:

No
